### PR TITLE
:sparkles: timer is started only by clicking start button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -63,15 +63,22 @@ body {
   bottom: 10%;
   left: 50%;
   transform: translate(-50%, -50%);
-  font-size: 3em;
-  font-weight: bold;
-  color: white;
-  text-align: center;
   z-index: 20;
-  user-select: none;
-  pointer-events: none;
   animation: pulse 1.2s infinite alternate;
   transition: opacity 0.6s ease;
+  user-select: none;
+
+  button {
+    border: none;
+    background-color: inherit;
+    cursor: pointer;
+    display: inline-block;
+    color: white;
+    font-size: 3em;
+    font-weight: bold;
+    text-align: center;
+    padding: 0.2em;
+  }
 }
 
 /* Animation de pulsation */

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
 <body>
 
-  <div id="startMessage">START</div>
+  <div id="startMessage"><button onclick="startAnimation()">START</button></div>
   <div id="timer">00:00</div>
   <div id="expandingDiv"></div>
   <div id="credits">made with ❤️ by Zenika</div>

--- a/js/app.js
+++ b/js/app.js
@@ -108,7 +108,7 @@ async function requestWakeLock() {
 
 function playBeep() {
   if (!soundEnabled) return;
-  
+
   const AudioContext = window.AudioContext || window.webkitAudioContext;
   const audioCtx = new AudioContext();
 
@@ -125,13 +125,6 @@ function playBeep() {
   oscillator.start();
   oscillator.stop(audioCtx.currentTime + 0.3); // play for 0.3s
 }
-
-// --- Démarrage au clic ---
-function onFirstClick() {
-  startAnimation();
-  document.removeEventListener('click', onFirstClick);
-}
-document.addEventListener('click', onFirstClick);
 
 // Wakelock: réactiver si la page revient au premier plan
 document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
This is related to #3 and #5 : 
While convenient to start the timer by clicking/pressing anywhere on the screen, this does not allow us to add a settings screen anywhere.

This PR makes it that only clicking/pressing the START button starts the timer.